### PR TITLE
Fix infinite NBT tag recursion in getUpdateTag(). Fixes #101.

### DIFF
--- a/src/main/java/com/rwtema/funkylocomotion/blocks/TileMovingBase.java
+++ b/src/main/java/com/rwtema/funkylocomotion/blocks/TileMovingBase.java
@@ -113,8 +113,10 @@ public abstract class TileMovingBase extends TileEntity implements ITickable {
 	@Nonnull
 	public NBTTagCompound writeToNBT(NBTTagCompound tag) {
 		super.writeToNBT(tag);
-		tag.setTag("BlockTag", block);
-		tag.setTag("DescTag", desc);
+		if (block != null)
+			tag.setTag("BlockTag", block);
+		if (desc != null)
+			tag.setTag("DescTag", desc);
 		tag.setInteger("Time", time);
 		tag.setInteger("MaxTime", maxTime);
 		tag.setByte("Dir", (byte) dir);

--- a/src/main/java/com/rwtema/funkylocomotion/blocks/TileMovingServer.java
+++ b/src/main/java/com/rwtema/funkylocomotion/blocks/TileMovingServer.java
@@ -1,5 +1,7 @@
 package com.rwtema.funkylocomotion.blocks;
 
+import java.lang.ref.WeakReference;
+import javax.annotation.Nonnull;
 import com.rwtema.funkylocomotion.movers.MoverEventHandler;
 import com.rwtema.funkylocomotion.movers.MovingTileRegistry;
 import net.minecraft.entity.player.EntityPlayer;
@@ -7,9 +9,6 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraftforge.fml.relauncher.Side;
-
-import javax.annotation.Nonnull;
-import java.lang.ref.WeakReference;
 
 public class TileMovingServer extends TileMovingBase {
 
@@ -26,25 +25,7 @@ public class TileMovingServer extends TileMovingBase {
 	@Override
 	@Nonnull
 	public NBTTagCompound getUpdateTag() {
-		if (desc == null)
-			return super.getUpdateTag();
-
-		super.writeToNBT(desc);
-
-		desc.setInteger("Time", time);
-		desc.setInteger("MaxTime", maxTime);
-		desc.setByte("Dir", (byte) dir);
-
-		if (lightLevel > 0)
-			desc.setByte("Light", (byte) lightLevel);
-		if (lightOpacity > 0)
-			desc.setShort("Opacity", (short) lightOpacity);
-
-		if (collisions.length > 0) {
-			desc.setTag("Collisions", TagsAxis(collisions));
-		}
-
-		return desc;
+		return this.writeToNBT(new NBTTagCompound());
 	}
 
 	@Override


### PR DESCRIPTION
I don't really know what the purpose of the TileMovingBase.desc tag is, and when it is supposed to be populated and why... so this fix might break stuff. But at least the current code causes an infinite NBT tag recursion when the getUpdateTag() calls writeToNBT() and gives it the desc tag to write to, and it then writes the desc tag inside itself.... This causes the clients to disconnect when they try to read that infinitely recursive tag and also causes StackOverflow fun on the server whenever something is moved on a dedicated server.