### PR TITLE
Add config option to force vanilla recipes

### DIFF
--- a/src/main/java/com/rwtema/funkylocomotion/FunkyLocomotion.java
+++ b/src/main/java/com/rwtema/funkylocomotion/FunkyLocomotion.java
@@ -50,6 +50,7 @@ public class FunkyLocomotion {
 		TilePusher.powerPerTile = config.get(Configuration.CATEGORY_GENERAL, "energyPerBlock", 250).getInt(250);
 		Recipes.shouldAddRecipes = config.get(Configuration.CATEGORY_GENERAL, "addRecipes", true).getBoolean(true);
 		Recipes.shouldAddFrameCopyResetRecipes = config.get(Configuration.CATEGORY_GENERAL, "addFrameCopyResetRecipes", true).getBoolean(true);
+		Recipes.shouldForceVanillaRecipes = config.get(Configuration.CATEGORY_GENERAL, "forceVanillaRecipes", false).getBoolean(false);
 		redrawChunksInstantly = config.get("client", "redrawChunksInstantly", true).getBoolean(true);
 		if (config.hasChanged())
 			config.save();

--- a/src/main/java/com/rwtema/funkylocomotion/Recipes.java
+++ b/src/main/java/com/rwtema/funkylocomotion/Recipes.java
@@ -28,6 +28,7 @@ import java.util.stream.Stream;
 public class Recipes {
 	public static boolean shouldAddRecipes;
 	public static boolean shouldAddFrameCopyResetRecipes;
+	public static boolean shouldForceVanillaRecipes;
 
 	@SubscribeEvent
 	public static void registerRecipes(RegistryEvent.Register<IRecipe> event) {
@@ -160,6 +161,7 @@ public class Recipes {
 	}
 
 	public static Object getOreWithVanillaFallback(Object vanillaFallback, String... moddedOre) {
+		if (shouldForceVanillaRecipes) return vanillaFallback;
 		for (String modOre : moddedOre) {
 			if (OreDictionary.getOres(modOre).size() > 0)
 				return modOre;


### PR DESCRIPTION
This PR adds another configuration option, `B:forceVanillaRecipes` to config category `general` which allows users to force recipes to use their vanilla variants, ignoring the presence of Signalum, Enderium, etc. It defaults to false, and will behave identically as before.